### PR TITLE
Fix attachment handling

### DIFF
--- a/includes/class-sasm-mail.php
+++ b/includes/class-sasm-mail.php
@@ -91,7 +91,7 @@ class SASMMail {
 
         if(!empty($attachments)){
 
-            foreach ($attachments as $key => $attachment) {
+            foreach ($attachments as $attachment) {
                 
                 $phpmailer->addAttachment($attachment);
 


### PR DESCRIPTION
When attaching files to the email, the $key value (aka : the AWS Access Key) was replaced in a foreach loop,
thus the AWS SES auth failed, and the error `The security token included in the request is invalid` appeared in the plugin's logs.